### PR TITLE
Make sure to check whether KakaoSDK already has an adapter…

### DIFF
--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -191,7 +191,11 @@ public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements A
   public RNKakaoLoginsModule(ReactApplicationContext reactContext) {
     super(reactContext);
     this.reactContext = reactContext;
-    KakaoSDK.init(new KakaoSDKAdapter(reactContext.getApplicationContext()));
+    if (KakaoSDK.getAdapter() == null) {
+      KakaoSDK.init(new KakaoSDKAdapter(reactContext.getApplicationContext()));
+    } else {
+      Session.getCurrentSession().clearCallbacks();
+    }
     reactContext.addActivityEventListener(this);
     callback = new SessionCallback();
     Session.getCurrentSession().addCallback(callback);


### PR DESCRIPTION
...before caling init. Fixes a crash issue that occurs when reloading the app through the Debug Menu