### PR TITLE
added header search path for react installed by cocoapod

### DIFF
--- a/ios/RNKakaoLogins.xcodeproj/project.pbxproj
+++ b/ios/RNKakaoLogins.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -247,6 +248,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = (


### PR DESCRIPTION
For react-native 0.60 React Libs are installed by pod
and this header search path has to be included.

<img width="661" alt="스크린샷 2019-07-04 오후 6 11 11" src="https://user-images.githubusercontent.com/22214150/60654584-38aac500-9e87-11e9-9b22-06afecc66643.png">
 