### PR TITLE
podspec 'homepage' 항목 업데이트

### DIFF
--- a/ios/RNKakaoLogins.podspec
+++ b/ios/RNKakaoLogins.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNKakaoLogins
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/react-native-seoul/react-native-kakao-logins"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
RN 0.60.x 부터 ios 프로젝트를 빌드할 때 CocoaPods 을 이용합니다. (https://facebook.github.io/react-native/blog/2019/07/03/version-60#cocoapods-by-default)
현재의 podspecs 파일은 (CocoaPods 최신 버전으로) pod install 할 때 필수인 homepage 항목이 공백이라 에러가 납니다.