### PR TITLE
fix native modules

### DIFF
--- a/KakaoLoginExample/App.js
+++ b/KakaoLoginExample/App.js
@@ -17,7 +17,7 @@ const TOKEN_EMPTY = 'token has not fetched';
 const PROFILE_EMPTY = {
   id: 'profile has not fetched',
   email: 'profile has not fetched',
-  profile_image_path: null,
+  profile_image_url: '',
 };
 
 export default function App() {
@@ -77,12 +77,12 @@ export default function App() {
     });
   };
 
-  const {id, email, profile_image_path: photo} = profile;
+  const {id, email, profile_image_url: photo} = profile;
 
   return (
     <View style={styles.container}>
       <View style={styles.profile}>
-        <Image style={styles.profilePhoto} source={{uri: photo || ''}} />
+        <Image style={styles.profilePhoto} source={{uri: photo}} />
         <Text>{`id : ${id}`}</Text>
         <Text>{`email : ${email}`}</Text>
       </View>

--- a/KakaoLoginExample/ios/Podfile.lock
+++ b/KakaoLoginExample/ios/Podfile.lock
@@ -185,7 +185,7 @@ SPEC CHECKSUMS:
   React-jsi: 4d8c9efb6312a9725b18d6fc818ffc103f60fec2
   React-jsiexecutor: 90ad2f9db09513fc763bc757fdc3c4ff8bde2a30
   React-jsinspector: e08662d1bf5b129a3d556eb9ea343a3f40353ae4
-  react-native-kakao-logins: 7343ceff8f648689b2f4711624927f0f5606725f
+  react-native-kakao-logins: fa43633accdd13d45e2ef980baa440b130bd9b75
   React-RCTActionSheet: b0f1ea83f4bf75fb966eae9bfc47b78c8d3efd90
   React-RCTAnimation: 359ba1b5690b1e87cc173558a78e82d35919333e
   React-RCTBlob: 5e2b55f76e9a1c7ae52b826923502ddc3238df24

--- a/README.md
+++ b/README.md
@@ -171,26 +171,29 @@ AUTHORIZATION_FAILED: invalid android_key_hash or ios_bundle_id or web_site_url
 
 | Func       | Param |                         Return                         | Description      |
 | :--------- | :---: | :----------------------------------------------------: | :--------------- |
-| login      |       | `callback (err: string, result: JSONObject in string)` | 로그인.          |
-| getProfile |       | `callback (err: string, result: JSONObject in string)` | 프로필 불러오기. |
-| logout     |       |        `callback (err: string, result: null)`        | 로그아웃.        |
+| login      |       | `callback (err: string, result: object)`               | 로그인.            |
+| getProfile |       | `callback (err: string, result: object)`               | 프로필 불러오기.     |
+| logout     |       | `callback (err: string, result: null)`                 | 로그아웃.           |
 
 #### params in result when `getProfile`
 
-|                      | iOS | Android | Comment            |
-| -------------------- | --- | ------- | ------------------ |
-| `id`                 | ✓   | ✓       | 카카오 고유 아이디 |
-| `nickname`           | ✓   | ✓       | 별칭               |
-| `email`              | ✓   | ✓       | 이메일 주소        |
-| `display_id`         |     | ✓       | 별칭 id            |
-| `phone_number`       |     | ✓       | 휴대폰 번호        |
-| `email_verified`     | ✓   | ✓       | 이메일 인증 여부   |
-| `kakaotalk_user`     |     | ✓       | 카카오톡 유저 여부 |
-| `profile_image_path` | ✓   | ✓       | 프로필 이미지      |
-| `thumb_image_path`   | ✓   | ✓       | 썸네일 이미지      |
-| `has_signed_up`      |     | ✓       | 가입 여부          |
+|                       | iOS | Android | Description           |
+| --------------------- | --- | ------- | --------------------- |
+| `id`                  |  ✓  |    ✓    | 카카오 고유 아이디        |
+| `nickname`            |  ✓  |    ✓    | 별칭        |
+| `profile_image_url`   |  ✓  |    ✓    | 프로필 이미지       |
+| `thumb_image_url`     |  ✓  |    ✓    | 썸네일 이미지       |
+| `email`               |  ✓  |    ✓    | 이메일 주소        |
+| `display_id`          |  ✓  |    ✓    | 별칭 id     |
+| `phone_number`        |  ✓  |    ✓    | 휴대폰 번호        |
+| `is_email_verified`   |  ✓  |    ✓    | 이메일 인증 여부     |
+| `is_kakaotalk_user`   |  ✓  |    ✓    | 카카오톡 유저 여부    |
+| `has_signed_up`       |  ✓  |    ✓    | 가입 여부     |
 
-- 4가지 attribute 대해 아직 ios에서 아직 어떻게 받는지 확인이 안되어 `android`와 상이한 부분이 있습니다.
+- `email` / `phone_number` / `display_id` / `is_email_verified` / `is_kakaotalk_user` / `has_signed_up`
+
+> 해당 값들은 사용자의 동의 혹은 제휴를 통해 권한이 부여된 특정 앱에서만 획득할 수 있습니다.
+권한이 있다면 그에 맞는 값을 리턴하고, 권한이 없다면 null 값을 반환합니다.
 
 ## Usage
 
@@ -257,7 +260,7 @@ export default function App() {
     });
   };
 
-  const {id, email, profile_image_path: photo} = profile;
+  const {id, email, profile_image_url: photo} = profile;
 
   return (
     <View style={styles.container}>

--- a/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
+++ b/android/src/main/java/com/dooboolab/kakaologins/RNKakaoLoginsModule.java
@@ -21,12 +21,14 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableMap;
 import com.kakao.auth.AccessTokenCallback;
 import com.kakao.auth.AuthType;
 import com.kakao.auth.ISessionCallback;
@@ -40,353 +42,351 @@ import com.kakao.usermgmt.callback.MeV2ResponseCallback;
 import com.kakao.usermgmt.response.MeV2Response;
 import com.kakao.usermgmt.response.model.UserAccount;
 import com.kakao.usermgmt.response.model.UserProfile;
+import com.kakao.util.OptionalBoolean;
 import com.kakao.util.exception.KakaoException;
 import com.kakao.util.helper.log.Logger;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class RNKakaoLoginsModule extends ReactContextBaseJavaModule implements ActivityEventListener, LifecycleEventListener{
-
-  private static final String TAG = "RNKakaoLoginModule";
-  private final ReactApplicationContext reactContext;
-  public static SessionCallback callback;
-  private static Callback loginCallback;
-
-  private static class Item {
-    final int textId;
-    public final int icon;
-    final int contentDescId;
-    final AuthType authType;
-    Item(final int textId, final Integer icon, final int contentDescId, final AuthType authType) {
-      this.textId = textId;
-      this.icon = icon;
-      this.contentDescId = contentDescId;
-      this.authType = authType;
+    
+    private static final String TAG = "RNKakaoLoginModule";
+    private final ReactApplicationContext reactContext;
+    public static SessionCallback callback;
+    private static Callback loginCallback;
+    
+    private static class Item {
+        final int textId;
+        public final int icon;
+        final int contentDescId;
+        final AuthType authType;
+        Item(final int textId, final Integer icon, final int contentDescId, final AuthType authType) {
+            this.textId = textId;
+            this.icon = icon;
+            this.contentDescId = contentDescId;
+            this.authType = authType;
+        }
     }
-  }
-
-  private List<AuthType> getAuthTypes() {
-    final List<AuthType> availableAuthTypes = new ArrayList<>();
-    if (Session.getCurrentSession().getAuthCodeManager().isTalkLoginAvailable()) {
-      availableAuthTypes.add(AuthType.KAKAO_TALK);
+    
+    private List<AuthType> getAuthTypes() {
+        final List<AuthType> availableAuthTypes = new ArrayList<>();
+        if (Session.getCurrentSession().getAuthCodeManager().isTalkLoginAvailable()) {
+            availableAuthTypes.add(AuthType.KAKAO_TALK);
+        }
+        if (Session.getCurrentSession().getAuthCodeManager().isStoryLoginAvailable()) {
+            availableAuthTypes.add(AuthType.KAKAO_STORY);
+        }
+        availableAuthTypes.add(AuthType.KAKAO_ACCOUNT);
+        
+        AuthType[] authTypes = KakaoSDK.getAdapter().getSessionConfig().getAuthTypes();
+        if (authTypes == null || authTypes.length == 0 || (authTypes.length == 1 && authTypes[0] == AuthType.KAKAO_LOGIN_ALL)) {
+            authTypes = AuthType.values();
+        }
+        availableAuthTypes.retainAll(Arrays.asList(authTypes));
+        
+        // 개발자가 설정한 것과 available 한 타입이 없다면 직접계정 입력이 뜨도록 한다.
+        if(availableAuthTypes.size() == 0){
+            availableAuthTypes.add(AuthType.KAKAO_ACCOUNT);
+        }
+        
+        return availableAuthTypes;
     }
-    if (Session.getCurrentSession().getAuthCodeManager().isStoryLoginAvailable()) {
-      availableAuthTypes.add(AuthType.KAKAO_STORY);
+    
+    private Item[] createAuthItemArray(final List<AuthType> authTypes) {
+        final List<Item> itemList = new ArrayList<Item>();
+        if(authTypes.contains(AuthType.KAKAO_TALK)) {
+            itemList.add(new Item(com.kakao.usermgmt.R.string.com_kakao_kakaotalk_account, com.kakao.usermgmt.R.drawable.talk, com.kakao.usermgmt.R.string.com_kakao_kakaotalk_account_tts, AuthType.KAKAO_TALK));
+        }
+        if(authTypes.contains(AuthType.KAKAO_STORY)) {
+            itemList.add(new Item(com.kakao.usermgmt.R.string.com_kakao_kakaostory_account, com.kakao.usermgmt.R.drawable.story, com.kakao.usermgmt.R.string.com_kakao_kakaostory_account_tts, AuthType.KAKAO_STORY));
+        }
+        if(authTypes.contains(AuthType.KAKAO_ACCOUNT)){
+            itemList.add(new Item(com.kakao.usermgmt.R.string.com_kakao_other_kakaoaccount, com.kakao.usermgmt.R.drawable.account, com.kakao.usermgmt.R.string.com_kakao_other_kakaoaccount_tts, AuthType.KAKAO_ACCOUNT));
+        }
+        
+        return itemList.toArray(new Item[itemList.size()]);
     }
-    availableAuthTypes.add(AuthType.KAKAO_ACCOUNT);
-
-    AuthType[] authTypes = KakaoSDK.getAdapter().getSessionConfig().getAuthTypes();
-    if (authTypes == null || authTypes.length == 0 || (authTypes.length == 1 && authTypes[0] == AuthType.KAKAO_LOGIN_ALL)) {
-      authTypes = AuthType.values();
+    
+    private void handleOptionalBooleanWithMap(WritableMap map, String key, OptionalBoolean bool){
+        switch(bool){
+            case NONE:
+                map.putNull(key);
+                break;
+            default:
+                map.putBoolean(key, bool.getBoolean());
+                break;
+        }
     }
-    availableAuthTypes.retainAll(Arrays.asList(authTypes));
-
-    // 개발자가 설정한 것과 available 한 타입이 없다면 직접계정 입력이 뜨도록 한다.
-    if(availableAuthTypes.size() == 0){
-      availableAuthTypes.add(AuthType.KAKAO_ACCOUNT);
-    }
-
-    return availableAuthTypes;
-  }
-
-  private Item[] createAuthItemArray(final List<AuthType> authTypes) {
-    final List<Item> itemList = new ArrayList<Item>();
-    if(authTypes.contains(AuthType.KAKAO_TALK)) {
-      itemList.add(new Item(com.kakao.usermgmt.R.string.com_kakao_kakaotalk_account, com.kakao.usermgmt.R.drawable.talk, com.kakao.usermgmt.R.string.com_kakao_kakaotalk_account_tts, AuthType.KAKAO_TALK));
-    }
-    if(authTypes.contains(AuthType.KAKAO_STORY)) {
-      itemList.add(new Item(com.kakao.usermgmt.R.string.com_kakao_kakaostory_account, com.kakao.usermgmt.R.drawable.story, com.kakao.usermgmt.R.string.com_kakao_kakaostory_account_tts, AuthType.KAKAO_STORY));
-    }
-    if(authTypes.contains(AuthType.KAKAO_ACCOUNT)){
-      itemList.add(new Item(com.kakao.usermgmt.R.string.com_kakao_other_kakaoaccount, com.kakao.usermgmt.R.drawable.account, com.kakao.usermgmt.R.string.com_kakao_other_kakaoaccount_tts, AuthType.KAKAO_ACCOUNT));
-    }
-
-    return itemList.toArray(new Item[itemList.size()]);
-  }
-
-  @SuppressWarnings("deprecation")
-  private ListAdapter createLoginAdapter(final Item[] authItems) {
+    
+    @SuppressWarnings("deprecation")
+    private ListAdapter createLoginAdapter(final Item[] authItems) {
         /*
-          가능한 auth type들을 유저에게 보여주기 위한 준비.
+         가능한 auth type들을 유저에게 보여주기 위한 준비.
          */
-    return new ArrayAdapter<Item>(
-        reactContext,
-        android.R.layout.select_dialog_item,
-        android.R.id.text1, authItems){
-      @Override
-      public View getView(int position, View convertView, ViewGroup parent) {
-        if (convertView == null) {
-          LayoutInflater inflater = (LayoutInflater) getContext()
-              .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-          convertView = inflater.inflate(com.kakao.usermgmt.R.layout.layout_login_item, parent, false);
+        return new ArrayAdapter<Item>(
+                                      reactContext,
+                                      android.R.layout.select_dialog_item,
+                                      android.R.id.text1, authItems){
+            @Override
+            public View getView(int position, View convertView, ViewGroup parent) {
+                if (convertView == null) {
+                    LayoutInflater inflater = (LayoutInflater) getContext()
+                    .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                    convertView = inflater.inflate(com.kakao.usermgmt.R.layout.layout_login_item, parent, false);
+                }
+                ImageView imageView = (ImageView) convertView.findViewById(com.kakao.usermgmt.R.id.login_method_icon);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    imageView.setImageDrawable(reactContext.getResources().getDrawable(authItems[position].icon, getContext().getTheme()));
+                } else {
+                    imageView.setImageDrawable(reactContext.getResources().getDrawable(authItems[position].icon));
+                }
+                TextView textView = (TextView) convertView.findViewById(com.kakao.usermgmt.R.id.login_method_text);
+                textView.setText(authItems[position].textId);
+                return convertView;
+            }
+        };
+    }
+    
+    /**
+     * 실제로 유저에게 보여질 dialog 객체를 생성한다.
+     * @param authItems 가능한 AuthType들의 정보를 담고 있는 Item array
+     * @param adapter Dialog의 list view에 쓰일 adapter
+     * @return 로그인 방법들을 팝업으로 보여줄 dialog
+     */
+    private Dialog createLoginDialog(final Item[] authItems, final ListAdapter adapter) {
+        final Dialog dialog = new Dialog(reactContext.getCurrentActivity(), com.kakao.usermgmt.R.style.LoginDialog);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        dialog.setContentView(com.kakao.usermgmt.R.layout.layout_login_dialog);
+        if (dialog.getWindow() != null) {
+            dialog.getWindow().setGravity(Gravity.CENTER);
         }
-        ImageView imageView = (ImageView) convertView.findViewById(com.kakao.usermgmt.R.id.login_method_icon);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-          imageView.setImageDrawable(reactContext.getResources().getDrawable(authItems[position].icon, getContext().getTheme()));
+        
+        //        TextView textView = (TextView) dialog.findViewById(R.id.login_title_text);
+        //        Typeface customFont = Typeface.createFromAsset(getContext().getAssets(), "fonts/KakaoOTFRegular.otf");
+        //        if (customFont != null) {
+        //            textView.setTypeface(customFont);
+        //        }
+        
+        ListView listView = (ListView) dialog.findViewById(com.kakao.usermgmt.R.id.login_list_view);
+        listView.setAdapter(adapter);
+        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                final AuthType authType = authItems[position].authType;
+                if (authType != null) {
+                    openSession(authType);
+                }
+                dialog.dismiss();
+            }
+        });
+        
+        Button closeButton = (Button) dialog.findViewById(com.kakao.usermgmt.R.id.login_close_button);
+        closeButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dialog.dismiss();
+            }
+        });
+        return dialog;
+    }
+    
+    public void openSession(final AuthType authType) {
+        Log.d(TAG, "openSession: " + authType.toString());
+        if (reactContext.getCurrentActivity() == null) {
+            Log.d(TAG, "getCurrentActivity is null.");
+        }
+        Session.getCurrentSession().open(authType, reactContext.getCurrentActivity());
+    }
+    
+    public RNKakaoLoginsModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.reactContext = reactContext;
+        if (KakaoSDK.getAdapter() == null) {
+            KakaoSDK.init(new KakaoSDKAdapter(reactContext.getApplicationContext()));
         } else {
-          imageView.setImageDrawable(reactContext.getResources().getDrawable(authItems[position].icon));
+            Session.getCurrentSession().clearCallbacks();
         }
-        TextView textView = (TextView) convertView.findViewById(com.kakao.usermgmt.R.id.login_method_text);
-        textView.setText(authItems[position].textId);
-        return convertView;
-      }
-    };
-  }
-
-  /**
-   * 실제로 유저에게 보여질 dialog 객체를 생성한다.
-   * @param authItems 가능한 AuthType들의 정보를 담고 있는 Item array
-   * @param adapter Dialog의 list view에 쓰일 adapter
-   * @return 로그인 방법들을 팝업으로 보여줄 dialog
-   */
-  private Dialog createLoginDialog(final Item[] authItems, final ListAdapter adapter) {
-    final Dialog dialog = new Dialog(reactContext.getCurrentActivity(), com.kakao.usermgmt.R.style.LoginDialog);
-    dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
-    dialog.setContentView(com.kakao.usermgmt.R.layout.layout_login_dialog);
-    if (dialog.getWindow() != null) {
-      dialog.getWindow().setGravity(Gravity.CENTER);
+        reactContext.addActivityEventListener(this);
+        callback = new SessionCallback();
+        Session.getCurrentSession().addCallback(callback);
+        Session.getCurrentSession().checkAndImplicitOpen();
     }
-
-//        TextView textView = (TextView) dialog.findViewById(R.id.login_title_text);
-//        Typeface customFont = Typeface.createFromAsset(getContext().getAssets(), "fonts/KakaoOTFRegular.otf");
-//        if (customFont != null) {
-//            textView.setTypeface(customFont);
-//        }
-
-    ListView listView = (ListView) dialog.findViewById(com.kakao.usermgmt.R.id.login_list_view);
-    listView.setAdapter(adapter);
-    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-      @Override
-      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        final AuthType authType = authItems[position].authType;
-        if (authType != null) {
-          openSession(authType);
-        }
-        dialog.dismiss();
-      }
-    });
-
-    Button closeButton = (Button) dialog.findViewById(com.kakao.usermgmt.R.id.login_close_button);
-    closeButton.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View v) {
-        dialog.dismiss();
-      }
-    });
-    return dialog;
-  }
-
-  public void openSession(final AuthType authType) {
-    Log.d(TAG, "openSession: " + authType.toString());
-    if (reactContext.getCurrentActivity() == null) {
-      Log.d(TAG, "getCurrentActivity is null.");
-    }
-    Session.getCurrentSession().open(authType, reactContext.getCurrentActivity());
-  }
-
-  public RNKakaoLoginsModule(ReactApplicationContext reactContext) {
-    super(reactContext);
-    this.reactContext = reactContext;
-    if (KakaoSDK.getAdapter() == null) {
-      KakaoSDK.init(new KakaoSDKAdapter(reactContext.getApplicationContext()));
-    } else {
-      Session.getCurrentSession().clearCallbacks();
-    }
-    reactContext.addActivityEventListener(this);
-    callback = new SessionCallback();
-    Session.getCurrentSession().addCallback(callback);
-    Session.getCurrentSession().checkAndImplicitOpen();
-  }
-
-  @Override
-  public String getName() {
-    return "RNKakaoLogins";
-  }
-
-  @ReactMethod
-  private void login(final Callback cb) {
-    loginCallback = cb;
-    // btnKakaoLogin.callOnClick();
-    final List<AuthType> authTypes = getAuthTypes();
-    if (authTypes.size() == 1) {
-      Session.getCurrentSession().open(authTypes.get(0), reactContext.getCurrentActivity());
-    } else {
-      final Item[] authItems = createAuthItemArray(authTypes);
-      ListAdapter adapter = createLoginAdapter(authItems);
-      final Dialog dialog = createLoginDialog(authItems, adapter);
-      dialog.show();
-    }
-  }
-
-  @ReactMethod
-  private void logout(final Callback cb) {
-    UserManagement.getInstance().requestLogout(new LogoutResponseCallback() {
-      @Override
-      public void onSessionClosed(ErrorResult errorResult) {
-        Log.w(TAG, "sessionClosed!!\n" + errorResult.toString());
-        cb.invoke(errorResult.toString(), null);
-      }
-      @Override
-      public void onNotSignedUp() {
-        Log.w(TAG, "NotSignedUp!!");
-      }
-      @Override
-      public void onSuccess(Long result) {
-        Log.d(TAG, "Logout!");
-        cb.invoke(null, String.valueOf(result));
-      }
-      @Override
-      public void onCompleteLogout() {
-        Log.d(TAG, "Complete Logout!");
-        cb.invoke(null, "Logged out");
-      }
-    });
-  }
-
-  @ReactMethod
-  private void getProfile(final Callback cb) {
-    Log.d(TAG, "getProfile");
-
-    UserManagement.getInstance().me(new MeV2ResponseCallback() {
-      @Override
-      public void onSessionClosed(ErrorResult errorResult) {
-
-      }
-
-      @Override
-      public void onSuccess(MeV2Response result) {
-        try {
-          JSONObject jsonObject = new JSONObject();
-
-          jsonObject.put("id", String.valueOf(result.getId()));
-          jsonObject.put("nickname", result.getNickname());
-          UserAccount kakaoAccount = result.getKakaoAccount();
-          if(kakaoAccount != null) {
-            jsonObject.put("email", kakaoAccount.getEmail());
-            jsonObject.put("display_id", kakaoAccount.getDisplayId());
-            jsonObject.put("phone_number", kakaoAccount.getPhoneNumber());
-            jsonObject.put("email_verified",  kakaoAccount.isEmailVerified().toString() == "TRUE");
-            jsonObject.put("kakaotalk_user", kakaoAccount.isKakaoTalkUser().toString() == "TRUE");
-          } else {
-            jsonObject.put("email", null);
-            jsonObject.put("display_id", null);
-            jsonObject.put("phone_number", null);
-            jsonObject.put("email_verified",  false);
-            jsonObject.put("kakaotalk_user", false);
-          }
-          jsonObject.put("profile_image_path", result.getProfileImagePath());
-          jsonObject.put("thumb_image_path", result.getThumbnailImagePath());
-          jsonObject.put("has_signed_up", result.hasSignedUp().toString() == "TRUE");
-
-          cb.invoke(null, jsonObject.toString());
-        } catch (JSONException e) {
-          cb.invoke(e.toString(), null);
-        }
-      }
-    });
-
-    /*
-    UserManagement.getInstance().requestMe(new MeResponseCallback() {
-      @Override
-      public void onFailure(ErrorResult errorResult) {
-        String message = "failed to get user info. msg=" + errorResult;
-        Log.e(TAG, message);
-        cb.invoke(message, null);
-      }
-
-      @Override
-      public void onSessionClosed(ErrorResult errorResult) {
-        Log.e(TAG, "sessionClosed");
-      }
-
-      @Override
-      public void onSuccess(UserProfile userProfile) {
-        try {
-          JSONObject jsonObject = new JSONObject();
-          jsonObject.put("nickname", userProfile.getNickname());
-          jsonObject.put("email", userProfile.getEmail());
-          jsonObject.put("emailVerified", userProfile.getEmailVerified());
-          jsonObject.put("thumbImagePath", userProfile.getThumbnailImagePath());
-          jsonObject.put("profileImagePath", userProfile.getProfileImagePath());
-          jsonObject.put("uuid", userProfile.getUUID());
-          jsonObject.put("serviceUserId", userProfile.getServiceUserId());
-          jsonObject.put("remainingInviteCount", userProfile.getRemainingInviteCount());
-          jsonObject.put("remainingGroupMsgCount", userProfile.getRemainingGroupMsgCount());
-          jsonObject.put("properties", userProfile.getProperties());
-          cb.invoke(null, jsonObject.toString());
-        } catch (JSONException e) {
-          cb.invoke(e.toString(), null);
-        }
-      }
-
-      @Override
-      public void onNotSignedUp() {
-        cb.invoke("NotSignedUp", null);
-      }
-    });
-    */
-  }
-
-  public static class SessionCallback implements ISessionCallback {
+    
     @Override
-    public void onSessionOpened() {
-      Log.d(TAG, "Logged in!\ntoken: " + Session.getCurrentSession().getAccessToken());
-
-      if (loginCallback != null) {
-        JSONObject response = new JSONObject();
-        String token = Session.getCurrentSession().getAccessToken();
-        try {
-          response.put("token",token);
-          loginCallback.invoke(null,response.toString());
-          loginCallback = null;
-        } catch (JSONException e) {
-          loginCallback.invoke(e.toString(), null);
-        }
-      }
+    public String getName() {
+        return "RNKakaoLogins";
     }
-
+    
+    @ReactMethod
+    private void login(final Callback cb) {
+        loginCallback = cb;
+        // btnKakaoLogin.callOnClick();
+        final List<AuthType> authTypes = getAuthTypes();
+        if (authTypes.size() == 1) {
+            Session.getCurrentSession().open(authTypes.get(0), reactContext.getCurrentActivity());
+        } else {
+            final Item[] authItems = createAuthItemArray(authTypes);
+            ListAdapter adapter = createLoginAdapter(authItems);
+            final Dialog dialog = createLoginDialog(authItems, adapter);
+            dialog.show();
+        }
+    }
+    
+    @ReactMethod
+    private void logout(final Callback cb) {
+        UserManagement.getInstance().requestLogout(new LogoutResponseCallback() {
+            @Override
+            public void onSessionClosed(ErrorResult errorResult) {
+                Log.w(TAG, "sessionClosed!!\n" + errorResult.toString());
+                cb.invoke(errorResult.toString(), null);
+            }
+            @Override
+            public void onNotSignedUp() {
+                Log.w(TAG, "NotSignedUp!!");
+            }
+            @Override
+            public void onSuccess(Long result) {
+                Log.d(TAG, "Logout!");
+                cb.invoke(null, String.valueOf(result));
+            }
+            @Override
+            public void onCompleteLogout() {
+                Log.d(TAG, "Complete Logout!");
+                cb.invoke(null, "Logged out");
+            }
+        });
+    }
+    
+    @ReactMethod
+    private void getProfile(final Callback cb) {
+        Log.d(TAG, "getProfile");
+        
+        UserManagement.getInstance().me(new MeV2ResponseCallback() {
+            @Override
+            public void onSessionClosed(ErrorResult errorResult) {
+                cb.invoke(errorResult.toString(), null);
+            }
+            
+            @Override
+            public void onSuccess(MeV2Response me) {
+                try {
+                    WritableMap profile = Arguments.createMap();
+                    UserAccount kakaoAccount = me.getKakaoAccount();
+                    
+                    profile.putString("id", String.valueOf(me.getId()));
+                    profile.putString("nickanme", kakaoAccount.getProfile().getNickname());
+                    profile.putString("email", kakaoAccount.getEmail());
+                    profile.putString("display_id", kakaoAccount.getDisplayId());
+                    profile.putString("phone_number", kakaoAccount.getPhoneNumber());
+                    profile.putString("profile_image_url", kakaoAccount.getProfile().getProfileImageUrl());
+                    profile.putString("thumb_image_url", kakaoAccount.getProfile().getThumbnailImageUrl());
+                    
+                    handleOptionalBooleanWithMap(profile, "is_email_verified", kakaoAccount.isEmailVerified());
+                    handleOptionalBooleanWithMap(profile, "is_kakaotalk_user", kakaoAccount.isKakaoTalkUser());
+                    handleOptionalBooleanWithMap(profile, "has_signed_up", me.hasSignedUp());
+                    
+                    cb.invoke(null, profile);
+                } catch (Exception e) {
+                    cb.invoke(e.toString(), null);
+                }
+            }
+        });
+        
+        /*
+         UserManagement.getInstance().requestMe(new MeResponseCallback() {
+         @Override
+         public void onFailure(ErrorResult errorResult) {
+         String message = "failed to get user info. msg=" + errorResult;
+         Log.e(TAG, message);
+         cb.invoke(message, null);
+         }
+         
+         @Override
+         public void onSessionClosed(ErrorResult errorResult) {
+         Log.e(TAG, "sessionClosed");
+         }
+         
+         @Override
+         public void onSuccess(UserProfile userProfile) {
+         try {
+         JSONObject jsonObject = new JSONObject();
+         jsonObject.put("nickname", userProfile.getNickname());
+         jsonObject.put("email", userProfile.getEmail());
+         jsonObject.put("emailVerified", userProfile.getEmailVerified());
+         jsonObject.put("thumbImagePath", userProfile.getThumbnailImagePath());
+         jsonObject.put("profileImagePath", userProfile.getProfileImagePath());
+         jsonObject.put("uuid", userProfile.getUUID());
+         jsonObject.put("serviceUserId", userProfile.getServiceUserId());
+         jsonObject.put("remainingInviteCount", userProfile.getRemainingInviteCount());
+         jsonObject.put("remainingGroupMsgCount", userProfile.getRemainingGroupMsgCount());
+         jsonObject.put("properties", userProfile.getProperties());
+         cb.invoke(null, jsonObject.toString());
+         } catch (JSONException e) {
+         cb.invoke(e.toString(), null);
+         }
+         }
+         
+         @Override
+         public void onNotSignedUp() {
+         cb.invoke("NotSignedUp", null);
+         }
+         });
+         */
+    }
+    
+    public static class SessionCallback implements ISessionCallback {
+        @Override
+        public void onSessionOpened() {
+            Log.d(TAG, "Logged in!\ntoken: " + Session.getCurrentSession().getTokenInfo().getAccessToken());
+            
+            if (loginCallback != null) {
+                WritableMap result = Arguments.createMap();
+                result.putString("token", Session.getCurrentSession().getTokenInfo().getAccessToken());
+                
+                loginCallback.invoke(null, result);
+                loginCallback = null;
+            }
+        }
+        
+        @Override
+        public void onSessionOpenFailed(KakaoException exception) {
+            if(exception != null) {
+                if (loginCallback != null) {
+                    loginCallback.invoke(null, exception.toString());
+                    loginCallback = null;
+                }
+                Log.e(TAG, "Logged in!\nSessionOpenFailed");
+                Logger.e(exception);
+            }
+        }
+    }
+    
     @Override
-    public void onSessionOpenFailed(KakaoException exception) {
-      if(exception != null) {
-        if (loginCallback != null) {
-          loginCallback.invoke(null, exception.toString());
-          loginCallback = null;
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        if (Session.getCurrentSession().handleActivityResult(requestCode, resultCode, data)){
+            return;
         }
-        Log.e(TAG, "Logged in!\nSessionOpenFailed");
-        Logger.e(exception);
-      }
     }
-  }
-
-  @Override
-  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-    if (Session.getCurrentSession().handleActivityResult(requestCode, resultCode, data)){
-      return;
+    
+    @Override
+    public void onNewIntent(Intent intent) {
+        
     }
-  }
-
-  @Override
-  public void onNewIntent(Intent intent) {
-
-  }
-
-  @Override
-  public void onHostDestroy() {
-    Session.getCurrentSession().removeCallback(this.callback);
-  }
-
-  @Override
-  public void onHostPause() {
-
-  }
-
-  @Override
-  public void onHostResume() {
-
-  }
+    
+    @Override
+    public void onHostDestroy() {
+        Session.getCurrentSession().removeCallback(this.callback);
+    }
+    
+    @Override
+    public void onHostPause() {
+        
+    }
+    
+    @Override
+    public void onHostResume() {
+        
+    }
 }

--- a/index.js
+++ b/index.js
@@ -3,27 +3,14 @@ import { NativeModules } from 'react-native';
 const { RNKakaoLogins } = NativeModules;
 
 const processNativeOutput = (userCallback) => {
-  return (errorString, resultString) => {
-    let error;
-    let resultJSON;
-
+  return (errorString, result) => {
     if (errorString) {
       error = new Error(errorString);
       userCallback(error, undefined);
-
       return;
     }
 
-    try {
-      resultJSON = JSON.parse(resultString);
-    } catch (_) {
-      error = new Error(resultString);
-      userCallback(error, undefined);
-
-      return;
-    }
-
-    userCallback(undefined, resultJSON);
+    userCallback(undefined, result);
   };
 }
 


### PR DESCRIPTION
@heyman333 작업하면서 몇가지 상이한 프로퍼티 이름을 변경했습니다.
프로미스 PR 까지 합쳐서, 버전을 2.0.0 으로 릴리즈하고, breaking changes 추가하는게 좋을 것 같아요!

------

### Use Native Map and Dictionary for javascript object
불필요한 JSON Parsing 과정 제거
> before
`Native String -> Convert to Javascript Object -> Javascript Object -> Use`

> after
`Native Object -> Javascript Object -> Use`


### Rename profile properties
카카오 응답결과와 상이한 변수명들 변경
```
profile_image_path -> profile_image_url
thumbnail_image_path -> thumbnail_image_url
kakaotalk_user -> is_kakaotalk_user
email_verified -> is_email_verified
```


### Support real-time profile
최신 카카오 SDK 에서 제공하는, 실시간 프로필 지원 (`nickname` `profile image` `thumbnail image`)


### Update doc
iOS `is_kakaotalk_user` 외 세가지 항목 지원 목록 업데이트
`is_kakaotalk_user, is_email_verified` 등 권한이 필요한 항목들 공식문서에 따른 설명 추가
